### PR TITLE
Add browser-based To-Do app (HTML/CSS/JS) with localStorage persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,17 @@
 # first-GIT
 
-This repository now contains a product-ready design and implementation blueprint for the JOOLA Teams Tournament Details page experience.
+A browser-based to-do app built with vanilla HTML, CSS, and JavaScript.
 
-- Spec document: `TOURNAMENT_DETAILS_PAGE_SPEC.md`
-- Focus tabs: `Format` and `Ratings & Seeding`
-- Stack: Next.js (App Router), Tailwind CSS, TypeScript, NestJS, Prisma/PostgreSQL
+## Features
+- Add tasks
+- Mark tasks as complete/incomplete
+- Filter by all, active, or completed tasks
+- Edit a task by double-clicking it
+- Delete individual tasks
+- Clear all completed tasks
+- Persistent storage via `localStorage`
+
+## Run locally
+1. Open `index.html` directly in your browser.
+2. Or run a static server in this folder (for example: `python3 -m http.server 8000`).
+3. Visit `http://localhost:8000`.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,202 @@
+const STORAGE_KEY = 'todo-app-items';
+
+const todoForm = document.getElementById('todo-form');
+const todoInput = document.getElementById('todo-input');
+const todoList = document.getElementById('todo-list');
+const taskCount = document.getElementById('task-count');
+const clearCompletedButton = document.getElementById('clear-completed');
+const emptyState = document.getElementById('empty-state');
+const filterButtons = document.querySelectorAll('.filter');
+
+let tasks = loadTasks();
+let currentFilter = 'all';
+
+function createTaskId() {
+  if (globalThis.crypto?.randomUUID) {
+    return globalThis.crypto.randomUUID();
+  }
+
+  return `task-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function loadTasks() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    const parsed = raw ? JSON.parse(raw) : [];
+
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return parsed.filter(
+      (task) => task && typeof task.id === 'string' && typeof task.text === 'string',
+    );
+  } catch {
+    return [];
+  }
+}
+
+function saveTasks() {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(tasks));
+}
+
+function getVisibleTasks() {
+  if (currentFilter === 'active') {
+    return tasks.filter((task) => !task.completed);
+  }
+
+  if (currentFilter === 'completed') {
+    return tasks.filter((task) => task.completed);
+  }
+
+  return tasks;
+}
+
+function updateCount() {
+  const remaining = tasks.filter((task) => !task.completed).length;
+  taskCount.textContent = `${remaining} task${remaining === 1 ? '' : 's'} left`;
+}
+
+function setFilter(nextFilter) {
+  currentFilter = nextFilter;
+  filterButtons.forEach((button) => {
+    const isActive = button.dataset.filter === nextFilter;
+    button.classList.toggle('is-active', isActive);
+    button.setAttribute('aria-selected', String(isActive));
+  });
+  renderTasks();
+}
+
+function createTaskElement(task) {
+  const li = document.createElement('li');
+  li.className = `todo-item${task.completed ? ' completed' : ''}`;
+  li.dataset.id = task.id;
+
+  const label = document.createElement('label');
+
+  const checkbox = document.createElement('input');
+  checkbox.type = 'checkbox';
+  checkbox.checked = task.completed;
+  checkbox.setAttribute('aria-label', `Mark ${task.text} complete`);
+  checkbox.addEventListener('change', () => toggleTask(task.id));
+
+  const text = document.createElement('span');
+  text.textContent = task.text;
+  text.title = 'Double-click to edit';
+  text.addEventListener('dblclick', () => startEditingTask(task.id, text));
+
+  label.append(checkbox, text);
+
+  const deleteButton = document.createElement('button');
+  deleteButton.type = 'button';
+  deleteButton.className = 'delete';
+  deleteButton.textContent = 'Delete';
+  deleteButton.addEventListener('click', () => removeTask(task.id));
+
+  li.append(label, deleteButton);
+  return li;
+}
+
+function renderTasks() {
+  todoList.innerHTML = '';
+
+  const visibleTasks = getVisibleTasks();
+  visibleTasks.forEach((task) => {
+    todoList.appendChild(createTaskElement(task));
+  });
+
+  emptyState.hidden = tasks.length !== 0;
+
+  updateCount();
+  saveTasks();
+}
+
+function addTask(text) {
+  tasks.unshift({
+    id: createTaskId(),
+    text,
+    completed: false,
+  });
+
+  renderTasks();
+}
+
+function toggleTask(id) {
+  tasks = tasks.map((task) =>
+    task.id === id ? { ...task, completed: !task.completed } : task,
+  );
+  renderTasks();
+}
+
+function updateTaskText(id, nextText) {
+  tasks = tasks.map((task) => (task.id === id ? { ...task, text: nextText } : task));
+  renderTasks();
+}
+
+function removeTask(id) {
+  tasks = tasks.filter((task) => task.id !== id);
+  renderTasks();
+}
+
+function clearCompleted() {
+  tasks = tasks.filter((task) => !task.completed);
+  renderTasks();
+}
+
+function startEditingTask(id, textElement) {
+  const originalText = textElement.textContent;
+  const input = document.createElement('input');
+  input.type = 'text';
+  input.className = 'edit-input';
+  input.value = originalText;
+  input.maxLength = 140;
+
+  const finishEditing = (commit) => {
+    const nextValue = input.value.trim();
+
+    if (commit && nextValue) {
+      updateTaskText(id, nextValue);
+    } else {
+      renderTasks();
+    }
+  };
+
+  input.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter') {
+      finishEditing(true);
+    }
+
+    if (event.key === 'Escape') {
+      finishEditing(false);
+    }
+  });
+
+  input.addEventListener('blur', () => finishEditing(true));
+
+  textElement.replaceWith(input);
+  input.focus();
+  input.select();
+}
+
+todoForm.addEventListener('submit', (event) => {
+  event.preventDefault();
+  const value = todoInput.value.trim();
+
+  if (!value) {
+    return;
+  }
+
+  addTask(value);
+  todoInput.value = '';
+  todoInput.focus();
+});
+
+filterButtons.forEach((button) => {
+  button.addEventListener('click', () => {
+    setFilter(button.dataset.filter);
+  });
+});
+
+clearCompletedButton.addEventListener('click', clearCompleted);
+
+setFilter('all');

--- a/index.html
+++ b/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>To-Do App</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="app" aria-label="To-Do Application">
+      <h1>To-Do List</h1>
+
+      <form id="todo-form" class="todo-form">
+        <label for="todo-input" class="sr-only">New task</label>
+        <input
+          id="todo-input"
+          type="text"
+          placeholder="Add a new task"
+          autocomplete="off"
+          maxlength="140"
+          required
+        />
+        <button type="submit">Add</button>
+      </form>
+
+      <section class="toolbar" aria-label="Task toolbar">
+        <div id="task-count" aria-live="polite">0 tasks left</div>
+        <div class="filters" role="tablist" aria-label="Task filter">
+          <button type="button" class="filter is-active" data-filter="all">All</button>
+          <button type="button" class="filter" data-filter="active">Active</button>
+          <button type="button" class="filter" data-filter="completed">Completed</button>
+        </div>
+        <button id="clear-completed" type="button">Clear completed</button>
+      </section>
+
+      <p id="empty-state" class="empty-state" hidden>No tasks yet. Add one above.</p>
+      <ul id="todo-list" class="todo-list" aria-label="Task list"></ul>
+    </main>
+
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,174 @@
+:root {
+  color-scheme: light;
+  font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+  --bg: #f3f4f6;
+  --surface: #ffffff;
+  --text: #111827;
+  --muted: #6b7280;
+  --accent: #2563eb;
+  --danger: #dc2626;
+  --border: #e5e7eb;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: var(--bg);
+  color: var(--text);
+}
+
+.app {
+  width: min(90vw, 640px);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 1.25rem;
+  box-shadow: 0 10px 30px rgb(0 0 0 / 0.08);
+}
+
+h1 {
+  margin: 0 0 1rem;
+}
+
+.todo-form {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.5rem;
+  margin-bottom: 0.85rem;
+}
+
+input,
+button {
+  font: inherit;
+}
+
+input {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.65rem 0.75rem;
+}
+
+button {
+  border: 1px solid transparent;
+  border-radius: 8px;
+  padding: 0.65rem 0.8rem;
+  cursor: pointer;
+  background: var(--accent);
+  color: #fff;
+}
+
+.toolbar {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.8rem;
+  color: var(--muted);
+}
+
+.filters {
+  display: flex;
+  justify-content: center;
+  gap: 0.3rem;
+}
+
+.filter {
+  background: transparent;
+  color: var(--muted);
+  border-color: var(--border);
+  padding: 0.3rem 0.55rem;
+}
+
+.filter.is-active {
+  color: var(--accent);
+  border-color: var(--accent);
+  background: rgb(37 99 235 / 0.1);
+}
+
+#clear-completed {
+  background: transparent;
+  border-color: var(--border);
+  color: var(--danger);
+}
+
+.empty-state {
+  margin: 0.2rem 0 0.8rem;
+  color: var(--muted);
+}
+
+.todo-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.45rem;
+}
+
+.todo-item {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: 0.5rem;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.6rem 0.7rem;
+}
+
+.todo-item label {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  min-width: 0;
+}
+
+.todo-item span {
+  overflow-wrap: anywhere;
+}
+
+.todo-item input[type='checkbox'] {
+  width: 1.05rem;
+  height: 1.05rem;
+}
+
+.todo-item.completed span {
+  text-decoration: line-through;
+  color: var(--muted);
+}
+
+.edit-input {
+  width: 100%;
+}
+
+.todo-item .delete {
+  background: transparent;
+  color: var(--danger);
+  border-color: var(--border);
+  padding: 0.3rem 0.55rem;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+@media (max-width: 620px) {
+  .toolbar {
+    grid-template-columns: 1fr;
+  }
+
+  .filters {
+    justify-content: flex-start;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a lightweight, no-build to-do application demo using vanilla HTML, CSS, and JavaScript for local usage and experimentation. 
- Offer a small accessible example that demonstrates task creation, editing, filtering, and persistence via `localStorage`.

### Description
- Add `index.html` containing the markup for the task form, toolbar, filters, empty state, and task list. 
- Add `app.js` implementing task CRUD, filtering (`all`, `active`, `completed`), inline editing, task ID generation, and persistence under the `STORAGE_KEY`. 
- Add `styles.css` with responsive, accessible styling and utility classes including `.sr-only`. 
- Update `README.md` to describe features and provide local run instructions.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c11cac5dfc832f9a1978b5c990d5d1)